### PR TITLE
Fix for #8: TypeError on scanning if the EIR is empty

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -102,7 +102,7 @@ function saveAdvertisement(peripheralId, address, addressType, connectable, adve
         //keep buffers as hex strings (by default buffers stringify unreadable into json)
         advToJson = { 
                       id: peripheralId,
-                      eir: advertisement.eir.toString('hex'),
+                      eir: advertisement.eir ? advertisement.eir.toString('hex') : '',
                       scanResponse: advertisement.scanResponse ? advertisement.scanResponse.toString('hex') : null,
                       decodedNonEditable : {
                         localName: advertisement.localName ? advertisement.localName : '',


### PR DESCRIPTION
Fix for #8.
Check if the EIR is empty in utils.js to avoid TypeError on scanning.
